### PR TITLE
Renamed RSA.h to PagarmeRSA

### DIFF
--- a/PagarMe/PagarMeCreditCard.m
+++ b/PagarMe/PagarMeCreditCard.m
@@ -11,7 +11,7 @@
 #import "PagarMeCreditCard.h"
 #import "PagarMe.h"
 #import "Luhn.h"
-#import "RSA.h"
+#import "PagarmeRSA.h"
 
 @interface PagarMeCreditCard ()
 
@@ -80,7 +80,7 @@
         NSString *publicKey = [responseObject objectForKey:@"public_key"];
         NSString *cardHashString = [self cardHashString];
         
-        NSString *encryptedString = [RSA encryptString:cardHashString publicKey:publicKey];
+        NSString *encryptedString = [PagarmeRSA encryptString:cardHashString publicKey:publicKey];
         
         _callbackBlock(nil, [NSString stringWithFormat:@"%@_%@", _id, encryptedString]);
         

--- a/PagarMe/RSA/PagarmeRSA.h
+++ b/PagarMe/RSA/PagarmeRSA.h
@@ -1,5 +1,5 @@
 //
-//  RSA.h
+//  PagarmeRSA.h
 //  My
 //
 //  Created by ideawu on 15-2-3.
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface RSA : NSObject
+@interface PagarmeRSA : NSObject
 
 + (NSString *)encryptString:(NSString *)str publicKey:(NSString *)pubKey;
 + (NSString *)encryptData:(NSData *)data publicKey:(NSString *)pubKey;

--- a/PagarMe/RSA/PagarmeRSA.m
+++ b/PagarMe/RSA/PagarmeRSA.m
@@ -1,15 +1,15 @@
 //
-//  RSA.m
+//  PagarmeRSA.m
 //  My
 //
 //  Created by ideawu on 15-2-3.
 //  Copyright (c) 2015年 ideawu. All rights reserved.
 //
 
-#import "RSA.h"
+#import "PagarmeRSA.h"
 #import <Security/Security.h>
 
-@implementation RSA
+@implementation PagarmeRSA
 
 static NSString *base64_encode_data(NSData *data){
 	data = [data base64EncodedDataWithOptions:0];
@@ -72,7 +72,7 @@ static NSData *base64_decode(NSString *str){
 	
 	// This will be base64 encoded, decode it.
 	NSData *data = base64_decode(key);
-	data = [RSA stripPublicKeyHeader:data];
+	data = [PagarmeRSA stripPublicKeyHeader:data];
 	if(!data){
 		return nil;
 	}
@@ -119,14 +119,14 @@ static NSData *base64_decode(NSString *str){
 
 + (NSString *)encryptString:(NSString *)str publicKey:(NSString *)pubKey{
 	NSData* data = [str dataUsingEncoding:NSUTF8StringEncoding];
-	return [RSA encryptData:data publicKey:pubKey];
+	return [PagarmeRSA encryptData:data publicKey:pubKey];
 }
 
 + (NSString *)encryptData:(NSData *)data publicKey:(NSString *)pubKey{
 	if(!data || !pubKey){
 		return nil;
 	}
-	SecKeyRef keyRef = [RSA addPublicKey:pubKey];
+	SecKeyRef keyRef = [PagarmeRSA addPublicKey:pubKey];
 	if(!keyRef){
 		return nil;
 	}


### PR DESCRIPTION
Fixes #8 

This fixes an issue where the rsa.h header files was conflicting with another libs that has a header with the same name. Example BoringSSL-GRPC has a header called rsa.h so when we try to build it, it conflicts with that file.
Just renaming the header.